### PR TITLE
Accelerometer sequencer state machine fix and improved response time

### DIFF
--- a/demo01_accelerometer_test/compile.do
+++ b/demo01_accelerometer_test/compile.do
@@ -1,0 +1,4 @@
+vlog sequencer.v
+vlog spi_master.v
+vlog top.v
+vlog top_tb.v

--- a/demo01_accelerometer_test/top.v
+++ b/demo01_accelerometer_test/top.v
@@ -20,6 +20,9 @@ wire [5:0] spi_nbits;
 wire spi_request;
 wire spi_ready;
 
+wire spi_csn;
+assign SEN_CS = spi_csn;
+
 sequencer U1 (
 	.clk_in(CLK12M),
 	.nrst(nrst),
@@ -30,7 +33,8 @@ sequencer U1 (
 	
 	.spi_request(spi_request),
 	.spi_ready(spi_ready),
-	
+	.spi_csn(spi_csn),
+
 	.led_out(LED)
 );
 
@@ -42,8 +46,8 @@ U2 (
 	.spi_sck(SEN_SPC),
 	.spi_mosi(SEN_SDI),
 	.spi_miso(SEN_SDO),
-	.spi_csn(SEN_CS),
-	
+	.spi_csn(spi_csn),
+
 	.mosi_data(spi_mosi_data),
 	.miso_data(spi_miso_data),
 	.nbits(spi_nbits),

--- a/demo01_accelerometer_test/top.v
+++ b/demo01_accelerometer_test/top.v
@@ -33,8 +33,9 @@ sequencer U1 (
 	
 	.led_out(LED)
 );
-	
-spi_master U2 (
+
+spi_master #(.div_coef(32'd200))
+U2 (
 	.clk_in(CLK12M),
 	.nrst(nrst),
 	

--- a/demo01_accelerometer_test/top_tb.v
+++ b/demo01_accelerometer_test/top_tb.v
@@ -28,15 +28,13 @@ spi_master #(.div_coef(32'd100))
 DUT2 (
 	.clk_in(CLK),
 	.nrst(NRESET),
-	.spi_clk(spi_clk),
-	.spi_sdo(spi_sdo),
-	.spi_sdi(spi_sdi),
-	.spi_cs(spi_cs),
-	
-	.data_in(data_in),
-	.data_out(data_out),
-	.n_bits(n_bits),    // n_bits==0 -> 1 bit transfer
-	
+	.spi_sck(spi_clk),
+	.spi_mosi(spi_sdo),
+	.spi_miso(spi_sdi),
+	.spi_csn(spi_cs),
+	.mosi_data(data_in),
+	.miso_data(data_out),
+	.nbits(n_bits),
 	.request(request),
 	.ready(ready)
 );


### PR DESCRIPTION
For convenience, a compile script was added along with an SPI port definition fix in the testbench. The sequencer also now correctly assigns the LEDs once the SPI read is finished. The SPI read speed was also set to update the LEDs about every 1ms.
[stp1.stp](https://github.com/user-attachments/files/15958752/stp1.zip)
